### PR TITLE
Implement Azure cli auth + update Kustomize and sopsGenerator versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,18 @@
-#v2.0.0 release
+# CHANGELOG
+
+## v3.0.0 release
+
+* Update Kustomize to v3.5.4 and Kustomize-Sops plugin to v1.2.1
+* Use Azure cli authentication [Issue #5](https://github.com/ingrammicro/kustomize-sops/issues/5)
+
+## v2.0.0 release
 
 * Use SopsGenerator exec kustomize plugin instead of Go plugin [Issue #2]
 
-#v1.0.1 release
+## v1.0.1 release
 
 * Several bugfixes
 
-#v1.0.0 release
+## v1.0.0 release
+
 * Build Docker image against https://github.com/Agilicus/kustomize-sops?ref=master 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,28 +1,31 @@
-ARG KUSTOMIZE_VERSION=v3.2.1
-ARG KUSTOMIZE_SOPS_PLUGIN_VERSION=1.1.0
+ARG KUSTOMIZE_VERSION=v3.5.4
+ARG KUSTOMIZE_SOPS_PLUGIN_VERSION=1.2.1
+ARG AZURE_CLI_VERSION=2.1.0-1~buster
 
-FROM golang:1.12-buster as builder
+FROM golang:1.13.8-buster as builder
 ARG KUSTOMIZE_VERSION
 
 RUN git clone https://github.com/kubernetes-sigs/kustomize.git
-RUN echo "replace sigs.k8s.io/kustomize/v3 v3.2.0 => ../../kustomize" >> kustomize/kustomize/go.mod
 RUN cd kustomize/kustomize && GO111MODULE=on go build -o /go/bin/kustomize 
 
 FROM debian:buster
 ARG KUSTOMIZE_VERSION
 ARG KUSTOMIZE_SOPS_PLUGIN_VERSION
+ARG AZURE_CLI_VERSION
 
 LABEL maintainer="imco@ingrammicro.com"
 
-RUN apt update && apt install -y curl git openssh-client  && \
+RUN apt update && apt install -y curl git openssh-client python3 python3-distutils gnupg lsb-release apt-transport-https && \
   mkdir -p "${XDG_CONFIG_HOME:-$HOME/.config}/kustomize/plugin/goabout.com/v1beta1/sopssecretgenerator" && \
   curl -Lo SopsSecretGenerator https://github.com/goabout/kustomize-sopssecretgenerator/releases/download/v${KUSTOMIZE_SOPS_PLUGIN_VERSION}/SopsSecretGenerator_${KUSTOMIZE_SOPS_PLUGIN_VERSION}_linux_amd64 && \
   chmod +x SopsSecretGenerator && \
   mv SopsSecretGenerator "${XDG_CONFIG_HOME:-$HOME/.config}/kustomize/plugin/goabout.com/v1beta1/sopssecretgenerator" && \
+  echo "Installing Azure CLI $AZURE_CLI_VERSION" && \
+  curl -sL https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor | tee /etc/apt/trusted.gpg.d/microsoft.asc.gpg > /dev/null && \
+  AZ_REPO=$(lsb_release -cs) && \
+  echo "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ $AZ_REPO main" | tee /etc/apt/sources.list.d/azure-cli.list && \
+  apt update && apt install azure-cli=$AZURE_CLI_VERSION && apt clean && \
   echo "."
-  # The Kustomize release on the GitHub page isn't really v3.2.1, and is therefor missing features we need
-  #curl -Lo /usr/bin/kustomize https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2F${KUSTOMIZE_VERSION}/kustomize_kustomize.${KUSTOMIZE_VERSION}_linux_amd64 && \
-  #chmod +x /usr/bin/kustomize
 
 COPY --from=builder /go/bin/kustomize /usr/local/bin/kustomize
 COPY /entrypoint.sh /entrypoint.sh

--- a/README.md
+++ b/README.md
@@ -1,19 +1,29 @@
 # kustomize-sops
 Docker image for Kustomize with Sops Exec plugin from https://github.com/goabout/kustomize-sopssecretgenerator
+This Kustomize-Sops image expects that Sops secrets are encrypted using Azure Key Vaults.
 
 ## Contents
-* Kustomize ~~v3.2.1~~ master (temporarily)
-* SopsSecretGenerator v1.1.0
+
+* Kustomize v3.5.4
+* SopsSecretGenerator v1.2.1
+
+## Requirements
+
+* Docker daemon
+* Azure CLI (to authenticate against Azure Key Vault) 
 
 ## Sops-secret resource format
 
 __kustomization.yaml__
-```
+
+```yaml
 generators:
   - SopsSecretGenerator.yaml
 ```
+
 __SopsSecretGenerator.yaml__
-```
+
+```yaml
 apiVersion: goabout.com/v1beta1
 kind: SopsSecretGenerator
 disableNameSuffixHash: true #default: false
@@ -24,25 +34,24 @@ envs:
 files:
   - secret-file.enc.yaml
 ```
+
 ## Usage
 
-`docker pull ingrammicro/kustomize-sops:v2.0.0`
+`docker pull ingrammicro/kustomize-sops:v3.0.0`
 
-```docker run ingrammicro/kustomize-sops:v2.0.0 -e AZURE_CLIENT_ID=xxxx -e AZURE_CLIENT_SECRET=xxx -e AZURE_TENANT_ID=xxxx -v KUSTOMIZE_OVERLAY:/kust [-v ~/.ssh/id_rsa:/root/.ssh/id_rsa]```
+```docker run ingrammicro/kustomize-sops:v3.0.0 -v ~/.azure:/root/.azure -v KUSTOMIZE_OVERLAY:/kust [-v ~/.ssh/id_rsa:/root/.ssh/id_rsa]```
 
 where:
 
 * KUSTOMIZE_OVERLAY is the path to your overlay directory that contains a kustomization.yaml
-* AZURE_CLIENT_ID
-* AZURE_CLIENT_SECRET
-* AZURE_TENANT_ID
 
 In case you are using a GitHub resource in your overlay that is a private repository, mount your the ssh key that is authorized to access GitHub with -v PATH_TO_ID_RSA_FILE:/root/.ssh/id_rsa
 
 If you are using a full base+overlay dir structure you can use following command:
 
-```docker run ingrammicro/kustomize-sops:v2.0.0 -e AZURE_CLIENT_ID=xxxx -e AZURE_CLIENT_SECRET=xxx -e AZURE_TENANT_ID=xxxx -v KUSTOMIZE_BASE:/kust [-v ~/.ssh/id_rsa:/root/.ssh/id_rsa] KUSTOMIZE_OVERLAY```
+```docker run ingrammicro/kustomize-sops:v3.0.0 -v ~/.azure:/root/.azure -v KUSTOMIZE_BASE:/kust [-v ~/.ssh/id_rsa:/root/.ssh/id_rsa] KUSTOMIZE_OVERLAY```
 
 where:
+
 * KUSTOMIZE_BASE is the path to your base directory that contains a kustomization.yaml
 * KUSTOMIZE_OVERLAY is the path to your overlay directory that contains a kustomization.yaml

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,9 +1,9 @@
 #!/bin/sh
 
-if [ -z "$AZURE_CLIENT_ID" ] || [ -z "$AZURE_CLIENT_SECRET" ] || [ -z "$AZURE_TENANT_ID" ]; then
+if [ ! -e "/root/.azure/accessTokens.json" ]; then
     echo "ERROR"
-    echo "Verify whether AZURE_CLIENT_ID, AZURE_CLIENT_SECRET AND AZURE_TENANT_ID variables are correctly set"
-    echo "and have permissions to access the Azure Vault used to encrypt the secrets"
+    echo "No Azure auth token found"
+    echo "Make sure you execute 'az login' in your command line before executing kustomize-sops"
     exit 1
 fi
 


### PR DESCRIPTION
Implements:

* Azure cli authentication (using user token instead of shared app credentials)

Updates:

* Kustomize v3.2.1 -> 3.5.4
* Goabout SopsSecretGenerator v1.1.0 -> v1.2.1  